### PR TITLE
Changed so that non-latex input always returns original reponse

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -154,6 +154,9 @@ def preview_function(response: str, params: Params) -> Result:
             sympy_out = sympy_out[0]
         sympy_out = str(sympy_out)
 
+        if not params.get("is_latex", False):
+            sympy_out = response
+
         if len(latex_out) > 1:
             latex_out = "\\left\\{"+",~".join(latex_out)+"\\right\\}"
         else:


### PR DESCRIPTION
The reason for this is that input which is turned into a list of expressions (e.g. if it contains plus_minus) then the stringification of the sympy expression will not always be valid in the sense that the evaluation function would handle the list of expressions.